### PR TITLE
remove readme anchor links to outdated Running & Limitations sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@
       <a href="https://github.com/nearprotocol/near-bindgen#writing-rust-contract">Writing Rust Contract</a>
       <span> | </span>
       <a href="https://github.com/nearprotocol/near-bindgen#building-rust-contract">Building Rust Contract</a>
-      <span> | </span>
-      <a href="https://github.com/nearprotocol/near-bindgen#running-rust-contract">Running Rust Contract</a>
-      <span> | </span>
-      <a href="https://github.com/nearprotocol/near-bindgen#limitations-and-future-work">Limitations and Future Work</a>
     </h3>
 </div>
 


### PR DESCRIPTION
Very simple clean-up of some anchor links in the README that pointed to a couple sections removed in this commit:
https://github.com/nearprotocol/near-bindgen/commit/61b0ef92326663fdc9fe43be50afea46f87ba2ab#diff-04c6e90faac2675aa89e2176d2eec7d8L251
